### PR TITLE
Use getFullUrl instead of getViewUrl

### DIFF
--- a/includes/jobs/GlobalNewFilesInsertJob.php
+++ b/includes/jobs/GlobalNewFilesInsertJob.php
@@ -37,7 +37,7 @@ class GlobalNewFilesInsertJob extends Job {
 				'files_page' => $config->get( 'Server' ) . $uploadedFile->getDescriptionUrl(),
 				'files_private' => (int)!$permissionManager->isEveryoneAllowed( 'read' ),
 				'files_timestamp' => $dbw->timestamp(),
-				'files_url' => $uploadedFile->getViewURL(),
+				'files_url' => $uploadedFile->getFullUrl(),
 				'files_uploader' => $centralIdLookup->centralIdFromLocalUser( $uploader ),
 			],
 			__METHOD__

--- a/includes/jobs/GlobalNewFilesMoveJob.php
+++ b/includes/jobs/GlobalNewFilesMoveJob.php
@@ -35,7 +35,7 @@ class GlobalNewFilesMoveJob extends Job implements GenericParameterJob {
 			'gnf_files',
 			[
 				'files_name' => $fileNew->getName(),
-				'files_url' => $fileNew->getViewURL(),
+				'files_url' => $fileNew->getFullUrl(),
 				'files_page' => $config->get( 'Server' ) . $fileNew->getDescriptionUrl(),
 			],
 			[


### PR DESCRIPTION
It appears using getViewUrl doesn't work on private wikis so the url ended up being /w/x rather then https:// or a actual url and not a path.