### PR TITLE
Use INDEX_FIELDS in getIndexField

### DIFF
--- a/includes/GlobalNewFilesPager.php
+++ b/includes/GlobalNewFilesPager.php
@@ -123,6 +123,10 @@ class GlobalNewFilesPager extends TablePager {
 		return $info;
 	}
 
+	public function getIndexField() {
+		return [ self::INDEX_FIELDS[$this->mSort] ];
+	}
+
 	public function getDefaultSort() {
 		return 'files_timestamp';
 	}


### PR DESCRIPTION
Prevent manually trying to sort for fields that are not indexed.