### PR TITLE
T12339: Add (untested) logging to hopefully catch it in prod

### DIFF
--- a/includes/jobs/GlobalNewFilesInsertJob.php
+++ b/includes/jobs/GlobalNewFilesInsertJob.php
@@ -42,7 +42,7 @@ class GlobalNewFilesInsertJob extends Job {
 					'cacheKey' => $cacheKey,
 				] );
 
-				$ttl = 'Unset for whatever reason';
+				$ttl = null;
 				$cachedData = $services->getMainWANObjectCache()->get( $cacheKey, $ttl );
 				$logger->debug( 'GlobalNewFilesInsertJob: Cached data for {name} (TTL: {ttl}): {cachedData}', [
 					'name' => $uploadedFile->getName(),

--- a/includes/jobs/GlobalNewFilesInsertJob.php
+++ b/includes/jobs/GlobalNewFilesInsertJob.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\WikiMap\WikiMap;
 
@@ -24,8 +25,37 @@ class GlobalNewFilesInsertJob extends Job {
 
 		$dbw = GlobalNewFilesHooks::getGlobalDB( DB_PRIMARY );
 
-		$uploader = $uploadedFile->getUploader( File::RAW ) ??
-				$services->getActorStore()->getUnknownActor();
+		$uploader = $uploadedFile->getUploader( File::RAW );
+		if ( $uploader === null ) {
+			$uploader = $services->getActorStore()->getUnknownActor();
+
+			// Slightly hacky logging in production for the elusive bug, T12339
+			$logger = LoggerFactory::getInstance( 'GlobalNewFiles' );
+			$logger->warning( 'GlobalNewFilesInsertJob: $uploader is null for {name}', [
+				'name' => $uploadedFile->getName(),
+			] );
+
+			try {
+				$cacheKey = $uploadedFile->getRepo()->getSharedCacheKey( 'file', sha1( $uploadedFile->getName() ) );
+				$logger->debug( 'GlobalNewFilesInsertJob: Cache key for {name}: {cacheKey}', [
+					'name' => $uploadedFile->getName(),
+					'cacheKey' => $cacheKey,
+				] );
+
+				$ttl = 'Unset for whatever reason';
+				$cachedData = $services->getMainWANObjectCache()->get( $cacheKey, $ttl );
+				$logger->debug( 'GlobalNewFilesInsertJob: Cached data for {name} (TTL: {ttl}): {cachedData}', [
+					'name' => $uploadedFile->getName(),
+					'ttl' => $ttl,
+					'cachedData' => $cachedData,
+				] );
+			} catch ( Exception $e ) {
+				$logger->warning( 'GlobalNewFilesInsertJob: Exception when grabbing internal MediaWiki details for {name}: {exception}', [
+					'name' => $uploadedFile->getName(),
+					'exception' => $e,
+				] );
+			}
+		}
 
 		$centralIdLookup = $services->getCentralIdLookup();
 

--- a/includes/jobs/GlobalNewFilesInsertJob.php
+++ b/includes/jobs/GlobalNewFilesInsertJob.php
@@ -26,7 +26,7 @@ class GlobalNewFilesInsertJob extends Job {
 		$dbw = GlobalNewFilesHooks::getGlobalDB( DB_PRIMARY );
 
 		$uploader = $uploadedFile->getUploader( File::RAW );
-		if ( $uploader === null ) {
+		if ( !$uploader ) {
 			$uploader = $services->getActorStore()->getUnknownActor();
 
 			// Slightly hacky logging in production for the elusive bug, T12339


### PR DESCRIPTION
@paladox and I tried to debug this bug with eval.php on #miraheze-tech, but we couldn't figure out why.

Since attaching a debugger to production is probably a no-go, we'll settle for debug prints instead.

(I also haven't tested the code BTW, I'm not even sure if it's syntactically correct)