### PR TITLE
gnf_files: Make sure files_dbname and files_name has a unique index

### DIFF
--- a/includes/jobs/GlobalNewFilesInsertJob.php
+++ b/includes/jobs/GlobalNewFilesInsertJob.php
@@ -29,47 +29,19 @@ class GlobalNewFilesInsertJob extends Job {
 
 		$dbw = GlobalNewFilesHooks::getGlobalDB( DB_PRIMARY );
 
-		$exists = $dbw->selectRowCount(
+		$dbw->upsert(
 			'gnf_files',
-			'*',
 			[
 				'files_dbname' => WikiMap::getCurrentWikiId(),
 				'files_name' => $uploadedFile->getName(),
 			],
-			__METHOD__,
-			[ 'LIMIT' => 1 ]
-		);
-
-		if ( $exists ) {
-			$dbw->update(
-				'gnf_files',
-				[
-					'files_timestamp' => $dbw->timestamp(),
-					'files_url' => $uploadedFile->getFullUrl(),
-					'files_uploader' => $this->userId,
-				],
-				[
-					'files_dbname' => WikiMap::getCurrentWikiId(),
-					'files_name' => $uploadedFile->getName(),
-				],
-				__METHOD__
-			);
-
-			return true;
-		}
-
-		$dbw->insert(
-			'gnf_files',
+			[ [ 'files_dbname', 'files_name' ] ],
 			[
 				'files_dbname' => WikiMap::getCurrentWikiId(),
-				'files_name' => $uploadedFile->getName(),
-				'files_page' => $config->get( 'Server' ) . $uploadedFile->getDescriptionUrl(),
-				'files_private' => (int)!$permissionManager->isEveryoneAllowed( 'read' ),
 				'files_timestamp' => $dbw->timestamp(),
 				'files_url' => $uploadedFile->getFullUrl(),
 				'files_uploader' => $this->userId,
-			],
-			__METHOD__
+			]
 		);
 
 		return true;

--- a/includes/jobs/GlobalNewFilesInsertJob.php
+++ b/includes/jobs/GlobalNewFilesInsertJob.php
@@ -38,9 +38,9 @@ class GlobalNewFilesInsertJob extends Job {
 			[ [ 'files_dbname', 'files_name' ] ],
 			[
 				'files_dbname' => WikiMap::getCurrentWikiId(),
- 				'files_name' => $uploadedFile->getName(),
- 				'files_page' => $config->get( 'Server' ) . $uploadedFile->getDescriptionUrl(),
- 				'files_private' => (int)!$permissionManager->isEveryoneAllowed( 'read' ),
+				'files_name' => $uploadedFile->getName(),
+				'files_page' => $config->get( 'Server' ) . $uploadedFile->getDescriptionUrl(),
+				'files_private' => (int)!$permissionManager->isEveryoneAllowed( 'read' ),
 				'files_timestamp' => $dbw->timestamp(),
 				'files_url' => $uploadedFile->getFullUrl(),
 				'files_uploader' => $this->userId,

--- a/includes/jobs/GlobalNewFilesInsertJob.php
+++ b/includes/jobs/GlobalNewFilesInsertJob.php
@@ -38,7 +38,6 @@ class GlobalNewFilesInsertJob extends Job {
 			[ [ 'files_dbname', 'files_name' ] ],
 			[
 				'files_dbname' => WikiMap::getCurrentWikiId(),
-				'files_dbname' => WikiMap::getCurrentWikiId(),
  				'files_name' => $uploadedFile->getName(),
  				'files_page' => $config->get( 'Server' ) . $uploadedFile->getDescriptionUrl(),
  				'files_private' => (int)!$permissionManager->isEveryoneAllowed( 'read' ),

--- a/includes/jobs/GlobalNewFilesInsertJob.php
+++ b/includes/jobs/GlobalNewFilesInsertJob.php
@@ -38,6 +38,10 @@ class GlobalNewFilesInsertJob extends Job {
 			[ [ 'files_dbname', 'files_name' ] ],
 			[
 				'files_dbname' => WikiMap::getCurrentWikiId(),
+				'files_dbname' => WikiMap::getCurrentWikiId(),
+ 				'files_name' => $uploadedFile->getName(),
+ 				'files_page' => $config->get( 'Server' ) . $uploadedFile->getDescriptionUrl(),
+ 				'files_private' => (int)!$permissionManager->isEveryoneAllowed( 'read' ),
 				'files_timestamp' => $dbw->timestamp(),
 				'files_url' => $uploadedFile->getFullUrl(),
 				'files_uploader' => $this->userId,

--- a/sql/gnf_files.sql
+++ b/sql/gnf_files.sql
@@ -13,4 +13,4 @@ CREATE INDEX /*i*/files_timestamp ON /*_*/gnf_files (files_timestamp);
 CREATE INDEX /*i*/files_name ON /*_*/gnf_files (files_name);
 CREATE INDEX /*i*/files_private ON /*_*/gnf_files (files_private);
 
-CREATE UNIQUE INDEX /*i*/files_name ON /*_*/gnf_files (files_dbname, files_name);
+CREATE UNIQUE INDEX /*i*/files_name_unique ON /*_*/gnf_files (files_dbname, files_name);

--- a/sql/gnf_files.sql
+++ b/sql/gnf_files.sql
@@ -5,9 +5,12 @@ CREATE TABLE /*_*/gnf_files (
   `files_name` VARCHAR(255) NOT NULL,
   `files_uploader` INT UNSIGNED NOT NULL,
   `files_private` TINYINT NOT NULL,
-  `files_timestamp`binary(14) NOT NULL
+  `files_timestamp`binary(14) NOT NULL,
+  UNIQUE KEY `uniqueperm`(perm_dbname,perm_group)
 ) /*$wgDBTableOptions*/;
 
 CREATE INDEX /*i*/files_dbname ON /*_*/gnf_files (files_dbname);
 CREATE INDEX /*i*/files_timestamp ON /*_*/gnf_files (files_timestamp);
 CREATE INDEX /*i*/files_name ON /*_*/gnf_files (files_name);
+
+CREATE UNIQUE INDEX /*i*/files_name ON /*_*/gnf_files (files_dbname, files_name);

--- a/sql/gnf_files.sql
+++ b/sql/gnf_files.sql
@@ -5,8 +5,7 @@ CREATE TABLE /*_*/gnf_files (
   `files_name` VARCHAR(255) NOT NULL,
   `files_uploader` INT UNSIGNED NOT NULL,
   `files_private` TINYINT NOT NULL,
-  `files_timestamp`binary(14) NOT NULL,
-  UNIQUE KEY `uniqueperm`(perm_dbname,perm_group)
+  `files_timestamp`binary(14) NOT NULL
 ) /*$wgDBTableOptions*/;
 
 CREATE INDEX /*i*/files_dbname ON /*_*/gnf_files (files_dbname);


### PR DESCRIPTION
Other wikis may have the same file name so all we want to make sure is that the same wiki does not have multiple entries for the same file.