### PR TITLE
Remove usage of getGlobalDB

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -9,8 +9,6 @@ use Miraheze\GlobalNewFiles\Jobs\GlobalNewFilesDeleteJob;
 use Miraheze\GlobalNewFiles\Jobs\GlobalNewFilesInsertJob;
 use Miraheze\GlobalNewFiles\Jobs\GlobalNewFilesMoveJob;
 use Miraheze\GlobalNewFiles\Maintenance\PopulateUploaderCentralIds;
-use Wikimedia\Rdbms\IDatabase;
-use Wikimedia\Rdbms\IReadableDatabase;
 
 class Hooks {
 
@@ -19,7 +17,8 @@ class Hooks {
 	}
 
 	public static function onCreateWikiStatePrivate( string $dbname ): void {
-		$dbw = self::getGlobalDB( DB_PRIMARY );
+		$connectionProvider = MediaWikiServices::getInstance()->getConnectionProvider();
+		$dbw = $connectionProvider->getPrimaryDatabase( 'virtual-globalnewfiles' );
 		$dbw->newUpdateQueryBuilder()
 			->update( 'gnf_files' )
 			->set( [ 'files_private' => 1 ] )
@@ -29,7 +28,8 @@ class Hooks {
 	}
 
 	public static function onCreateWikiStatePublic( string $dbname ): void {
-		$dbw = self::getGlobalDB( DB_PRIMARY );
+		$connectionProvider = MediaWikiServices::getInstance()->getConnectionProvider();
+		$dbw = $connectionProvider->getPrimaryDatabase( 'virtual-globalnewfiles' );
 		$dbw->newUpdateQueryBuilder()
 			->update( 'gnf_files' )
 			->set( [ 'files_private' => 0 ] )
@@ -123,15 +123,5 @@ class Hooks {
 			__DIR__ . '/../sql/patches/patch-gnf_files-drop-files_user.sql',
 			true,
 		] );
-	}
-
-	public static function getGlobalDB( int $index, ?string $group = null ): IDatabase|IReadableDatabase {
-		$connectionProvider = MediaWikiServices::getInstance()->getConnectionProvider();
-
-		if ( $index === DB_PRIMARY ) {
-			return $connectionProvider->getPrimaryDatabase( 'virtual-globalnewfiles' );
-		}
-
-		return $connectionProvider->getReplicaDatabase( 'virtual-globalnewfiles', $group );
 	}
 }

--- a/includes/Jobs/GlobalNewFilesDeleteJob.php
+++ b/includes/Jobs/GlobalNewFilesDeleteJob.php
@@ -6,7 +6,6 @@ use Job;
 use MediaWiki\MainConfigNames;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
-use Miraheze\GlobalNewFiles\Hooks;
 
 class GlobalNewFilesDeleteJob extends Job {
 
@@ -19,7 +18,8 @@ class GlobalNewFilesDeleteJob extends Job {
 	 */
 	public function run(): bool {
 		$config = MediaWikiServices::getInstance()->getMainConfig();
-		$dbw = Hooks::getGlobalDB( DB_PRIMARY );
+		$connectionProvider = MediaWikiServices::getInstance()->getConnectionProvider();
+		$dbw = $connectionProvider->getPrimaryDatabase( 'virtual-globalnewfiles' );
 
 		$dbw->newDeleteQueryBuilder()
 			->deleteFrom( 'gnf_files' )

--- a/includes/Jobs/GlobalNewFilesInsertJob.php
+++ b/includes/Jobs/GlobalNewFilesInsertJob.php
@@ -6,7 +6,6 @@ use Job;
 use MediaWiki\MainConfigNames;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
-use Miraheze\GlobalNewFiles\Hooks;
 
 class GlobalNewFilesInsertJob extends Job {
 
@@ -27,7 +26,9 @@ class GlobalNewFilesInsertJob extends Job {
 		$permissionManager = $services->getPermissionManager();
 
 		$uploadedFile = $services->getRepoGroup()->getLocalRepo()->newFile( $this->getTitle() );
-		$dbw = Hooks::getGlobalDB( DB_PRIMARY );
+
+		$connectionProvider = $services->getConnectionProvider();
+		$dbw = $connectionProvider->getPrimaryDatabase( 'virtual-globalnewfiles' );
 
 		$exists = (bool)$dbw->newSelectQueryBuilder()
 			->select( '*' )

--- a/includes/Jobs/GlobalNewFilesMoveJob.php
+++ b/includes/Jobs/GlobalNewFilesMoveJob.php
@@ -7,7 +7,6 @@ use Job;
 use MediaWiki\MainConfigNames;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
-use Miraheze\GlobalNewFiles\Hooks;
 
 class GlobalNewFilesMoveJob extends Job implements GenericParameterJob {
 
@@ -26,7 +25,9 @@ class GlobalNewFilesMoveJob extends Job implements GenericParameterJob {
 	 */
 	public function run(): bool {
 		$config = MediaWikiServices::getInstance()->getMainConfig();
-		$dbw = Hooks::getGlobalDB( DB_PRIMARY );
+
+		$connectionProvider = MediaWikiServices::getInstance()->getConnectionProvider();
+		$dbw = $connectionProvider->getPrimaryDatabase( 'virtual-globalnewfiles' );
 
 		$fileOld = MediaWikiServices::getInstance()->getRepoGroup()->getLocalRepo()->newFile( $this->oldTitle );
 		$fileNew = MediaWikiServices::getInstance()->getRepoGroup()->getLocalRepo()->newFile( $this->newTitle );


### PR DESCRIPTION
To prepare for full HookHandlers/Service injection migrations.